### PR TITLE
[Riot Api추가] 사용할 라이엇 api관련 처리 추가

### DIFF
--- a/src/main/java/com/projectteam/coop/tft/domain/LeagueEntry.java
+++ b/src/main/java/com/projectteam/coop/tft/domain/LeagueEntry.java
@@ -1,0 +1,26 @@
+package com.projectteam.coop.tft.domain;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+@Entity
+@Getter @Setter
+public class LeagueEntry {
+    private String leagueId;
+    private String queueType;
+    private String tier;
+    private String rank;
+    private String summonerId;
+    @Id
+    private String summonerName;
+    private int leaguePoints;
+    private int wins;
+    private int losses;
+    private boolean veteran;
+    private boolean inactive;
+    private boolean freshBlood;
+    private boolean hotStreak;
+}

--- a/src/main/java/com/projectteam/coop/tft/domain/MatchDesc.java
+++ b/src/main/java/com/projectteam/coop/tft/domain/MatchDesc.java
@@ -1,0 +1,53 @@
+package com.projectteam.coop.tft.domain;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.*;
+
+@Entity
+@NoArgsConstructor
+@Getter @Setter
+@IdClass(MatchDescId.class)
+public class MatchDesc {
+
+    @Id
+    private String metadataParticipants;
+    @Id
+    private String metaDateMatchId;
+    //전체 게임 시간
+    private long gameLength;
+    private String gameVersion;
+    // $ 혹은 | 를 입력해서 데이터화 시킬 예정 List 대부분 그럴예정
+    private String augments;
+
+    private String companionContentID;
+    private int companionSkinID;
+    private String companionSpecies;
+
+    private int placement;
+    private String puuid;
+
+    @Column(length=1000)
+    private String traitsName;
+    private String traitsNumUnits;
+    // 이 특성의 현재 스타일입니다. (0 = 스타일 없음, 1 = 브론즈, 2 = 실버, 3 = 골드, 4 = 유채색)
+    private String traitsStyle;
+    // 토탈 티어중에 Current가 몇 달성했는지
+    private String traitsTierCurrent;
+    private String traitsTierTotal;
+
+    private String unitsCharacterId;
+    @Column(length=1000)
+    private String unitsItemNames;
+    /*private String unitsItems;*/
+    private String unitsName;
+    // 희귀도 0 ~ 4 까지 1골드 ~ 5골드
+    private String unitsRarity;
+    // 1 ~ 3 티어
+    private String unitstier;
+
+    private String tftGameType;
+    private int tftSetNumber;
+}

--- a/src/main/java/com/projectteam/coop/tft/domain/MatchDescDTO.java
+++ b/src/main/java/com/projectteam/coop/tft/domain/MatchDescDTO.java
@@ -1,0 +1,74 @@
+package com.projectteam.coop.tft.domain;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter @Setter
+public class MatchDescDTO {
+    private Info info;
+    private Metadata metadata;
+
+    @Getter @Setter
+    public static class Metadata {
+        private List<String> participants;
+        private String match_id;
+        private String data_version;
+    }
+
+    @Getter @Setter
+    public static class Info {
+        private long game_datetime;
+        private long game_length;
+        private String game_version;
+        private List<Participants> participants;
+
+        @Getter @Setter
+        public static class Participants {
+            private List<String> augments;
+
+            private Companion companion;
+            @Getter @Setter
+            public static class Companion {
+                private String content_ID;
+                private int skin_ID;
+                private String species;
+            }
+
+            private int gold_left;
+            private int last_round;
+            private int level;
+            private int placement;
+            private int players_eliminated;
+            private String puuid;
+            private long time_eliminated;
+            private int total_damage_to_players;
+
+            private List<Traits> traits;
+            @Getter @Setter
+            public static class Traits {
+                private String name;
+                private int num_units;
+                private int style;
+                private int tier_current;
+                private int tier_total;
+            }
+
+            private List<Units> units;
+            @Getter @Setter
+            public static class Units{
+                private String character_id;
+                private List<String> itemNames;
+                private List<Integer> items;
+                private String name;
+                private int rarity;
+                private int tier;
+            }
+        }
+
+        private int queue_id;
+        private String tft_game_type;
+        private int tft_set_number;
+    }
+}

--- a/src/main/java/com/projectteam/coop/tft/domain/MatchDescId.java
+++ b/src/main/java/com/projectteam/coop/tft/domain/MatchDescId.java
@@ -1,0 +1,17 @@
+package com.projectteam.coop.tft.domain;
+
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@NoArgsConstructor
+public class MatchDescId implements Serializable {
+    private static final long serialVersionUID = 5735022999922182249L;
+
+    @EqualsAndHashCode.Include
+    public String metadataParticipants;
+    @EqualsAndHashCode.Include
+    public String metaDateMatchId;
+}

--- a/src/main/java/com/projectteam/coop/tft/domain/Summoner.java
+++ b/src/main/java/com/projectteam/coop/tft/domain/Summoner.java
@@ -1,0 +1,21 @@
+package com.projectteam.coop.tft.domain;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+@Entity
+@Getter @Setter
+public class Summoner {
+
+    private String accountId;
+    private int profileIconId;
+    private long revisionDate;
+    private String name;
+    @Id
+    private String id;
+    private String puuid;
+    private long summonerLevel;
+}

--- a/src/main/java/com/projectteam/coop/tft/domain/Synergy.java
+++ b/src/main/java/com/projectteam/coop/tft/domain/Synergy.java
@@ -1,0 +1,26 @@
+package com.projectteam.coop.tft.domain;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+@Entity
+@Getter @Setter
+public class Synergy {
+    @Id
+    private String traitsName;
+    private String traitsNameKr;
+    private String traitsDesc;
+    private String traitsTier;
+    @Column(length=1000)
+    private String traitsTierDesc;
+    private String traitsNumUnits;
+    private String traitsNumUnitsKr;
+
+    private String winRate;
+    private String usedAnotherUnit;
+    private String usedAugments;
+}

--- a/src/main/java/com/projectteam/coop/tft/domain/UsedAugment.java
+++ b/src/main/java/com/projectteam/coop/tft/domain/UsedAugment.java
@@ -1,0 +1,20 @@
+package com.projectteam.coop.tft.domain;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class UsedAugment implements Comparable<UsedAugment> {
+    private String usedAnotherAugment;
+    private int count = 0;
+
+    @Override
+    public int compareTo(UsedAugment usedAugment) {
+        if (usedAugment.count > count) {
+            return 1;
+        } else if (usedAugment.count < count) {
+            return -1;
+        }
+        return 0;
+    }
+}

--- a/src/main/java/com/projectteam/coop/tft/domain/UsedUnit.java
+++ b/src/main/java/com/projectteam/coop/tft/domain/UsedUnit.java
@@ -1,0 +1,20 @@
+package com.projectteam.coop.tft.domain;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class UsedUnit implements Comparable<UsedUnit>{
+    private String usedAnotherUnit;
+    private int count = 0;
+
+    @Override
+    public int compareTo(UsedUnit usedUnit) {
+        if (usedUnit.count > count) {
+            return 1;
+        } else if (usedUnit.count < count) {
+            return -1;
+        }
+        return 0;
+    }
+}

--- a/src/main/java/com/projectteam/coop/tft/repository/LeagueEntryRepository.java
+++ b/src/main/java/com/projectteam/coop/tft/repository/LeagueEntryRepository.java
@@ -1,0 +1,27 @@
+package com.projectteam.coop.tft.repository;
+
+import com.projectteam.coop.tft.domain.LeagueEntry;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import java.util.List;
+
+@Repository
+@Transactional("h2TxManager")
+public class LeagueEntryRepository {
+
+    @PersistenceContext(unitName = "h2Jpa")
+    private EntityManager em;
+
+    public String addTftLeagueEntry(LeagueEntry leagueEntry) {
+        em.persist(leagueEntry);
+        return leagueEntry.getLeagueId();
+    }
+
+    public List<LeagueEntry> findAll() {
+        return em.createQuery("select m from LeagueEntry m", LeagueEntry.class)
+                .getResultList();
+    }
+}

--- a/src/main/java/com/projectteam/coop/tft/repository/MatchDescRepository.java
+++ b/src/main/java/com/projectteam/coop/tft/repository/MatchDescRepository.java
@@ -1,0 +1,32 @@
+package com.projectteam.coop.tft.repository;
+
+import com.projectteam.coop.tft.domain.MatchDesc;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import java.util.List;
+
+@Repository
+public class MatchDescRepository {
+
+    @PersistenceContext(unitName = "h2Jpa")
+    private EntityManager em;
+
+    public String addTftDescData(MatchDesc matchDesc) {
+        em.persist(matchDesc);
+        return matchDesc.getMetaDateMatchId();
+    }
+
+    public boolean searchTftMatchIdData(String matchId){
+        int size = em.createQuery("select m from MatchDesc m where m.metaDateMatchId = '" + matchId +"'", MatchDesc.class).getResultList().size();
+        if (size > 0) {
+            return false;
+        }
+        return true;
+    }
+
+    public List<MatchDesc> searchTftPlacementData(int placement){
+        return em.createQuery("select m from MatchDesc m where m.placement = '" + placement + "'", MatchDesc.class).getResultList();
+    }
+}

--- a/src/main/java/com/projectteam/coop/tft/repository/SummonerRepository.java
+++ b/src/main/java/com/projectteam/coop/tft/repository/SummonerRepository.java
@@ -1,0 +1,25 @@
+package com.projectteam.coop.tft.repository;
+
+import com.projectteam.coop.tft.domain.Summoner;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import java.util.List;
+
+@Repository
+public class SummonerRepository {
+
+    @PersistenceContext(unitName = "h2Jpa")
+    private EntityManager em;
+
+    public String addTftSummoner(Summoner summoner) {
+        em.persist(summoner);
+        return summoner.getAccountId();
+    }
+
+    public List<Summoner> findAll() {
+        return em.createQuery("select m from Summoner m", Summoner.class)
+                .getResultList();
+    }
+}

--- a/src/main/java/com/projectteam/coop/tft/repository/SynergyRepository.java
+++ b/src/main/java/com/projectteam/coop/tft/repository/SynergyRepository.java
@@ -1,0 +1,38 @@
+package com.projectteam.coop.tft.repository;
+
+import com.projectteam.coop.sample.jpa.domain.JpaSample;
+import com.projectteam.coop.tft.domain.Summoner;
+import com.projectteam.coop.tft.domain.Synergy;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import java.util.List;
+
+@Repository
+public class SynergyRepository {
+    @PersistenceContext(unitName = "h2Jpa")
+    private EntityManager em;
+
+    public String addSynergy(Synergy synergy) {
+        em.persist(synergy);
+        return synergy.getTraitsName();
+    }
+
+    public List<Synergy> findSynergy(String synergyName) {
+        return em.createQuery("select m from Synergy m where m.traitsName = '" + synergyName +"'", Synergy.class).getResultList();
+    }
+
+    public List<Synergy> findAll() {
+        return em.createQuery("select m from Synergy m", Synergy.class)
+                .getResultList();
+    }
+
+    public String updateWinRateUnits(String winRate, String units, String Augments,String traitsName){
+        Synergy synergy = em.find(Synergy.class, traitsName);
+        synergy.setWinRate(winRate);
+        synergy.setUsedAugments(Augments);
+        synergy.setUsedAnotherUnit(units);
+        return synergy.getTraitsName();
+    }
+}

--- a/src/main/java/com/projectteam/coop/tft/service/LeagueEntryService.java
+++ b/src/main/java/com/projectteam/coop/tft/service/LeagueEntryService.java
@@ -1,0 +1,27 @@
+package com.projectteam.coop.tft.service;
+
+import com.projectteam.coop.tft.domain.LeagueEntry;
+import com.projectteam.coop.tft.repository.LeagueEntryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(transactionManager = "h2TxManager")
+@RequiredArgsConstructor
+public class LeagueEntryService {
+
+    private final LeagueEntryRepository leagueEntryRepository;
+
+    public void addTftLeagueEntry(List<LeagueEntry> LeagueEntryData) {
+        for(int i=0; i<LeagueEntryData.size(); i++) {
+            leagueEntryRepository.addTftLeagueEntry(LeagueEntryData.get(i));
+        }
+    }
+
+    public List<LeagueEntry> searchTftLeagueEntry(){
+        return leagueEntryRepository.findAll();
+    }
+}

--- a/src/main/java/com/projectteam/coop/tft/service/MatchDescService.java
+++ b/src/main/java/com/projectteam/coop/tft/service/MatchDescService.java
@@ -1,0 +1,135 @@
+package com.projectteam.coop.tft.service;
+
+import com.projectteam.coop.tft.domain.MatchDesc;
+import com.projectteam.coop.tft.domain.MatchDescDTO;
+import com.projectteam.coop.tft.repository.MatchDescRepository;
+import com.projectteam.coop.util.TftUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Transactional(transactionManager = "h2TxManager")
+@RequiredArgsConstructor
+public class MatchDescService {
+
+    private final MatchDescRepository matchDescRepository;
+    private final TftUtil tftUtil = new TftUtil();
+    private final String tftVersion = "Version 12.6";
+
+    public void addMatchDesc(String puuid, String apikey) {
+        List<MatchDesc> matchDesc;
+        List<String> MatchId = tftUtil.getTftMatchId(puuid, 1,apikey);
+        for(int i=0; i<MatchId.size(); i++) {
+            try {
+                MatchDescDTO matchDescDTO = tftUtil.getTftMatchDesc(MatchId.get(i), apikey);
+                if(matchDescDTO.getInfo().getGame_version().indexOf(tftVersion) != -1) {
+                    if(matchDescRepository.searchTftMatchIdData(matchDescDTO.getMetadata().getMatch_id()) == true) {
+                        matchDesc = makeMatchDesc(matchDescDTO);
+                        for (int j = 0; j < matchDesc.size(); j++) {
+                            matchDescRepository.addTftDescData(matchDesc.get(j));
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                System.out.println("데이터 수집에 문제가 되는 버전입니다.");
+            }
+        }
+    }
+
+    public List<MatchDesc> makeMatchDesc(MatchDescDTO MatchData){
+        List<MatchDesc> matchDescList = new ArrayList<>();
+        int i=0, j=0, k=0;
+        String tmp="", traitsName="", traitsUnits="", traitsStyle="", tierCurrent="", tierTotal="";
+        String character_id="", itemNames="", itemNames2="", name="", rarity="", tier="";
+
+        for(i=0; i<MatchData.getMetadata().getParticipants().size(); i++){
+            MatchDesc matchDesc = new MatchDesc();
+            matchDesc.setMetadataParticipants(MatchData.getMetadata().getParticipants().get(i));
+            matchDesc.setMetaDateMatchId(MatchData.getMetadata().getMatch_id());
+
+            matchDesc.setGameLength(MatchData.getInfo().getGame_length());
+            matchDesc.setGameVersion(MatchData.getInfo().getGame_version());
+
+            tmp="";
+            for(j=0; j<MatchData.getInfo().getParticipants().get(i).getAugments().size(); j++) {
+                tmp += MatchData.getInfo().getParticipants().get(i).getAugments().get(j) + "|";
+            }
+            tmp = tmp.substring(0, tmp.length() - 1);
+            matchDesc.setAugments(tmp);
+
+            matchDesc.setCompanionContentID(MatchData.getInfo().getParticipants().get(i).getCompanion().getContent_ID());
+            matchDesc.setCompanionSkinID(MatchData.getInfo().getParticipants().get(i).getCompanion().getSkin_ID());
+            matchDesc.setCompanionSpecies(MatchData.getInfo().getParticipants().get(i).getCompanion().getSpecies());
+
+            matchDesc.setPlacement(MatchData.getInfo().getParticipants().get(i).getPlacement());
+            matchDesc.setPuuid(MatchData.getInfo().getParticipants().get(i).getPuuid());
+
+            traitsName="";
+            traitsUnits="";
+            traitsStyle="";
+            tierCurrent="";
+            tierTotal="";
+            for(j=0; j<MatchData.getInfo().getParticipants().get(i).getTraits().size(); j++) {
+                traitsName += MatchData.getInfo().getParticipants().get(i).getTraits().get(j).getName() + "|";
+                traitsUnits += MatchData.getInfo().getParticipants().get(i).getTraits().get(j).getNum_units() + "|";
+                traitsStyle += MatchData.getInfo().getParticipants().get(i).getTraits().get(j).getStyle() + "|";
+                tierCurrent += MatchData.getInfo().getParticipants().get(i).getTraits().get(j).getTier_current() + "|";
+                tierTotal += MatchData.getInfo().getParticipants().get(i).getTraits().get(j).getTier_total() + "|";
+            }
+
+            traitsName = traitsName.substring(0,traitsName.length()-1);
+            traitsUnits = traitsUnits.substring(0,traitsUnits.length()-1);
+            traitsStyle = traitsStyle.substring(0,traitsStyle.length()-1);
+            tierCurrent = tierCurrent.substring(0,tierCurrent.length()-1);
+            tierTotal = tierTotal.substring(0,tierTotal.length()-1);
+
+            matchDesc.setTraitsName(traitsName);
+            matchDesc.setTraitsNumUnits(traitsUnits);
+            matchDesc.setTraitsStyle(traitsStyle);
+            matchDesc.setTraitsTierCurrent(tierCurrent);
+            matchDesc.setTraitsTierTotal(tierTotal);
+
+            character_id="";
+            itemNames="";
+            name="";
+            rarity="";
+            tier="";
+            for(j=0; j<MatchData.getInfo().getParticipants().get(i).getUnits().size(); j++) {
+                character_id += MatchData.getInfo().getParticipants().get(i).getUnits().get(j).getCharacter_id() + "|";
+                itemNames2 = "";
+                for(k=0; k<MatchData.getInfo().getParticipants().get(i).getUnits().get(j).getItemNames().size(); k++){
+                    itemNames2 += MatchData.getInfo().getParticipants().get(i).getUnits().get(j).getItemNames().get(k) + "$";
+                }
+                if(itemNames2.isEmpty() != true) {
+                    itemNames2 = itemNames2.substring(0, itemNames2.length() - 1);
+                }
+                itemNames += itemNames2 + "|";
+                name += MatchData.getInfo().getParticipants().get(i).getUnits().get(j).getName() + "|";
+                rarity += MatchData.getInfo().getParticipants().get(i).getUnits().get(j).getRarity() + "|";
+                tier += MatchData.getInfo().getParticipants().get(i).getUnits().get(j).getTier() + "|";
+            }
+
+            character_id = character_id.substring(0,character_id.length()-1);
+            itemNames = itemNames.substring(0,itemNames.length()-1);
+            name = name.substring(0,name.length()-1);
+            rarity = rarity.substring(0,rarity.length()-1);
+            tier = tier.substring(0,tier.length()-1);
+
+            matchDesc.setUnitsCharacterId(character_id);
+            matchDesc.setUnitsItemNames(itemNames);
+            matchDesc.setUnitsName(name);
+            matchDesc.setUnitsRarity(rarity);
+            matchDesc.setUnitstier(tier);
+
+            matchDesc.setTftGameType(MatchData.getInfo().getTft_game_type());
+            matchDesc.setTftSetNumber(MatchData.getInfo().getTft_set_number());
+
+            matchDescList.add(matchDesc);
+        }
+        return matchDescList;
+    }
+}

--- a/src/main/java/com/projectteam/coop/tft/service/SummonerService.java
+++ b/src/main/java/com/projectteam/coop/tft/service/SummonerService.java
@@ -1,0 +1,25 @@
+package com.projectteam.coop.tft.service;
+
+import com.projectteam.coop.tft.domain.Summoner;
+import com.projectteam.coop.tft.repository.SummonerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(transactionManager = "h2TxManager")
+@RequiredArgsConstructor
+public class SummonerService {
+
+    private final SummonerRepository summonerRepository;
+
+    public void setTftSummoner(Summoner summoner) {
+        summonerRepository.addTftSummoner(summoner);
+    }
+
+    public List<Summoner> searchSummonerDataEntry(){
+        return summonerRepository.findAll();
+    }
+}

--- a/src/main/java/com/projectteam/coop/tft/service/SynergyService.java
+++ b/src/main/java/com/projectteam/coop/tft/service/SynergyService.java
@@ -1,0 +1,115 @@
+package com.projectteam.coop.tft.service;
+
+import com.projectteam.coop.tft.domain.MatchDesc;
+import com.projectteam.coop.tft.domain.Synergy;
+import com.projectteam.coop.tft.domain.UsedAugment;
+import com.projectteam.coop.tft.domain.UsedUnit;
+import com.projectteam.coop.tft.repository.MatchDescRepository;
+import com.projectteam.coop.tft.repository.SynergyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@Service
+@Transactional(transactionManager = "h2TxManager")
+@RequiredArgsConstructor
+public class SynergyService {
+
+    private final MatchDescRepository matchDescRepository;
+    private final SynergyRepository synergyRepository;
+
+    public void initSynergyDesc() {
+        List<MatchDesc> matchDescData = matchDescRepository.searchTftPlacementData(1);
+        List<Synergy> synergyList = synergyRepository.findAll();
+        double winPoint;
+
+        for (Synergy synergy : synergyList) {
+            winPoint = 0;
+            List<UsedUnit> usedUnitList = new ArrayList<>();
+            List<UsedAugment> usedAugmentsList = new ArrayList<>();
+            for (MatchDesc matchDescDatum : matchDescData) {
+                if (matchDescDatum.getTraitsName().contains(synergy.getTraitsName())) {
+                    String[] TraitsName = matchDescDatum.getTraitsName().split("\\|");
+                    String[] TraitsStyle = matchDescDatum.getTraitsStyle().split("\\|");
+                    for (int k = 0; k < TraitsName.length; k++) {
+                        if (synergy.getTraitsName().equals(TraitsName[k]) && !"0".equals(TraitsStyle[k])) {
+                            winPoint++;
+                            usedUnitList = usedSynergyUnitCount(usedUnitList, matchDescDatum.getUnitsCharacterId());
+                            usedAugmentsList = usedAugmentCount(usedAugmentsList, matchDescDatum.getAugments());
+                        }
+                    }
+                }
+            }
+
+            Collections.sort(usedUnitList);
+            Collections.sort(usedAugmentsList);
+            winPoint = winPoint / matchDescData.size() * 100;
+            StringBuilder usedUnits = new StringBuilder();
+            StringBuilder usedAugments = new StringBuilder();
+            if(usedUnitList.size() != 0) {
+                for (int i = 0; i < 5; i++) {
+                    usedUnits.append(usedUnitList.get(i).getUsedAnotherUnit()).append("|");
+                }
+                for (int i = 0; i < 3; i++) {
+                    usedAugments.append(usedAugmentsList.get(i).getUsedAnotherAugment()).append("|");
+                }
+                usedUnits = new StringBuilder(usedUnits.substring(0, usedUnits.length() - 1));
+                usedAugments = new StringBuilder(usedAugments.substring(0, usedAugments.length() - 1));
+            }
+
+            synergyRepository.updateWinRateUnits(String.format("%.2f",winPoint), usedUnits.toString(), usedAugments.toString(), synergy.getTraitsName());
+        }
+    }
+
+    public List<UsedUnit> usedSynergyUnitCount(List<UsedUnit> usedUnitList, String usedUnit){
+        String[] usedUnitArray = usedUnit.split("\\|");
+        boolean umuFlg;
+
+        for (String s : usedUnitArray) {
+            umuFlg = false;
+            for (UsedUnit unit : usedUnitList) {
+                if (unit.getUsedAnotherUnit().equals(s)) {
+                    unit.setCount(unit.getCount() + 1);
+                    umuFlg = true;
+                }
+            }
+            if (umuFlg) {
+                continue;
+            }
+
+            UsedUnit usedUnits = new UsedUnit();
+            usedUnits.setUsedAnotherUnit(s);
+            usedUnits.setCount(1);
+            usedUnitList.add(usedUnits);
+        }
+        return usedUnitList;
+    }
+
+    public List<UsedAugment> usedAugmentCount(List<UsedAugment> usedAugmentsList, String usedAugment){
+        String[] usedAugmentsArray = usedAugment.split("\\|");
+        boolean umuFlg;
+
+        for (String s : usedAugmentsArray) {
+            umuFlg = false;
+            for (UsedAugment unit : usedAugmentsList) {
+                if (unit.getUsedAnotherAugment().equals(s)) {
+                    unit.setCount(unit.getCount() + 1);
+                    umuFlg = true;
+                }
+            }
+            if (umuFlg) {
+                continue;
+            }
+
+            UsedAugment usedAugments = new UsedAugment();
+            usedAugments.setUsedAnotherAugment(s);
+            usedAugments.setCount(1);
+            usedAugmentsList.add(usedAugments);
+        }
+        return usedAugmentsList;
+    }
+}

--- a/src/main/java/com/projectteam/coop/util/TftUtil.java
+++ b/src/main/java/com/projectteam/coop/util/TftUtil.java
@@ -1,0 +1,130 @@
+package com.projectteam.coop.util;
+
+import com.projectteam.coop.tft.domain.LeagueEntry;
+import com.projectteam.coop.tft.domain.MatchDescDTO;
+import com.projectteam.coop.tft.domain.Summoner;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.*;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.web.client.DefaultResponseErrorHandler;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.List;
+
+public class TftUtil {
+
+    /*
+     * getTftSummoner 닉네임으로 아이디 정보 확인 함수
+     * */
+    public Summoner getTftSummoner(String summonerId, String apikey) {
+
+        String uri = "https://kr.api.riotgames.com/tft/summoner/v1/summoners/" + summonerId;
+        UriComponents uriComponents = UriComponentsBuilder.fromHttpUrl(uri)
+                .queryParam("api_key", apikey)
+                .build(false);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(new MediaType("application", "json", Charset.forName("utf-8")));
+
+        RestTemplate restTemplate = new RestTemplate();
+        restTemplate.setErrorHandler(new DefaultResponseErrorHandler() {
+            public boolean hasError(ClientHttpResponse response) throws IOException {
+                HttpStatus code = response.getStatusCode();
+                if (code == HttpStatus.UNAUTHORIZED) {
+                    throw new HttpClientErrorException(HttpStatus.UNAUTHORIZED);
+                }
+                return false;
+            }
+        });
+
+        ResponseEntity<Summoner> SummonerData = restTemplate.exchange(uriComponents.toUriString(), HttpMethod.GET, new HttpEntity<>(headers), Summoner.class);
+
+        return SummonerData.getBody();
+    }
+
+    /*
+     * getTftSummoner 닉네임으로 아이디 정보 확인 함수
+     * */
+    public List<String> getTftMatchId(String puuid, int count, String apikey) {
+        String uri = "https://asia.api.riotgames.com/tft/match/v1/matches/by-puuid/" + puuid + "/ids?count="+ count;
+        UriComponents uriComponents = UriComponentsBuilder.fromHttpUrl(uri)
+                .queryParam("api_key", apikey)
+                .build(false);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(new MediaType("application", "json", Charset.forName("utf-8")));
+
+        RestTemplate restTemplate = new RestTemplate();
+        restTemplate.setErrorHandler(new DefaultResponseErrorHandler() {
+            public boolean hasError(ClientHttpResponse response) throws IOException {
+                HttpStatus code = response.getStatusCode();
+                if (code == HttpStatus.UNAUTHORIZED) {
+                    throw new HttpClientErrorException(HttpStatus.UNAUTHORIZED);
+                }
+                return false;
+            }
+        });
+
+        List<String> tftMatchIdList = restTemplate.getForObject(uriComponents.toUriString(), List.class);
+        return tftMatchIdList;
+    }
+
+    /*
+     * getTftMatchDesc 매치 데이터 수집 함수
+     * MatchId 찾는 매치 아이디
+     * */
+    public MatchDescDTO getTftMatchDesc(String MatchId, String apikey) {
+        String uri = "https://asia.api.riotgames.com/tft/match/v1/matches/" + MatchId;
+        UriComponents uriComponents = UriComponentsBuilder.fromHttpUrl(uri)
+                .queryParam("api_key", apikey)
+                .build(false);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(new MediaType("application", "json", Charset.forName("utf-8")));
+
+        RestTemplate restTemplate = new RestTemplate();
+        restTemplate.setErrorHandler(new DefaultResponseErrorHandler() {
+            public boolean hasError(ClientHttpResponse response) throws IOException {
+                HttpStatus code = response.getStatusCode();
+                if (code == HttpStatus.UNAUTHORIZED) {
+                    throw new HttpClientErrorException(HttpStatus.UNAUTHORIZED);
+                }
+                return false;
+            }
+        });
+
+        ResponseEntity<MatchDescDTO> MatchData = restTemplate.exchange(uriComponents.toUriString(), HttpMethod.GET, new HttpEntity<>(headers), MatchDescDTO.class);
+
+        return MatchData.getBody();
+    }
+
+    public List<LeagueEntry> getTftLeagueEntry(String tier, String division, int page, String apikey) {
+        String uri = "https://kr.api.riotgames.com/tft/league/v1/entries/" + tier + "/" + division + "?page=" + page;
+        UriComponents uriComponents = UriComponentsBuilder.fromHttpUrl(uri)
+                .queryParam("api_key", apikey)
+                .build(false);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(new MediaType("application", "json", Charset.forName("utf-8")));
+
+        RestTemplate restTemplate = new RestTemplate();
+        restTemplate.setErrorHandler(new DefaultResponseErrorHandler() {
+            public boolean hasError(ClientHttpResponse response) throws IOException {
+                HttpStatus code = response.getStatusCode();
+                if (code == HttpStatus.UNAUTHORIZED) {
+                    throw new HttpClientErrorException(HttpStatus.UNAUTHORIZED);
+                }
+                return false;
+            }
+        });
+
+        ResponseEntity<List<LeagueEntry>> LeagueEntryData = restTemplate.exchange(uriComponents.toUriString(), HttpMethod.GET, null, new ParameterizedTypeReference<List<LeagueEntry>>() {});
+
+        return LeagueEntryData.getBody();
+    }
+}


### PR DESCRIPTION
기본적인 아이디 검색
아이디 정보 기준으로 matchid 출력 함수
matchid를 이용한 매치정보 수집함수
아이언 -> 다이아까지의 평범한 유저 정보 수집 함수추가

※ 대량으로 사용 해야 하는 함수들 대부분 속도제한으로 인해서 수집에 어려움이 있으므로 DB관련 데이터는 한번 수집한것을 기준으로 사용하는 것이 좋을듯 보임