### PR TITLE
[헤더 검색기능 추가] 챔피언 검색 기능

### DIFF
--- a/src/main/resources/static/css/fragments/bodyHeader.css
+++ b/src/main/resources/static/css/fragments/bodyHeader.css
@@ -1,8 +1,3 @@
-.header{
-    margin-bottom: 0px;
-    padding: 0px;
-}
-
 @media ( max-width: 1000px ) {
     .Search-Summoner{
         margin-left: 10px;
@@ -15,6 +10,8 @@
 }
 
 .header {
+    margin-bottom: 0px;
+    padding: 0px;
     background-repeat: no-repeat;
     background-position: center;
     background-size: cover;
@@ -34,7 +31,7 @@
     border-bottom: 1px solid #000000;
 }
 
-.Search-Champion{
+.searchChampion{
     margin-left: 10px
 }
 
@@ -43,4 +40,18 @@
     background-position: center;
     background-size: cover;
     padding-bottom: 140px;
+}
+
+.hide {
+    display: none !important;
+}
+
+.championKeyword:hover{
+    background-color: #0dcaf0;
+    cursor: pointer;
+}
+
+.championKeyword{
+    --bs-bg-opacity: 1;
+    background-color: rgba(var(--bs-light-rgb), var(--bs-bg-opacity));
 }

--- a/src/main/resources/static/js/tft/bodyHeader.js
+++ b/src/main/resources/static/js/tft/bodyHeader.js
@@ -1,0 +1,63 @@
+const championNameList = ["Ahri","Alistar","Ashe","Blitzcrank","Brand","Braum","Caitlyn","Camille","ChoGath","Corki","Darius","Draven","Ekko","Ezreal","Galio","Gangplank","Gnar","Illaoi","Irelia","JarvanIV","Jayce","Jhin","Jinx","Kaisa","Kassadin","KhaZix","Leona","Lucian","Lulu","Malzahar","MissFortune","Morgana","Nocturne","Orianna","Poppy","Quinn","RekSai","Renata","Sejuani","Senna","Seraphine","Silco","Singed","Sivir","Swain","Syndra","TahmKench","Talon","Tryndamere","Twitch","Veigar","Vex","Vi","Viktor","Warwick","Zac","Zeri","Ziggs","Zilean","Zyra"];
+const championNameKrList = ["아리","알리스타","애쉬","블리츠크랭크","브랜드","브라움","케이틀린","카밀","초가스","코르키","다리우스","드레이븐","에코","이즈리얼","갈리오","갱플랭크","나르","일라오이","이렐리아","자르반4세","제이스","진","징크스","카이사","카사딘","카직스","레오나","루시안","룰루","말자하","미스포츈","모르가나","녹턴","오리아나","뽀삐","퀸","렉사이","레나타글라스크","세주아니","세나","세라핀","실코","신지드","시비르","스웨인","신드라","탐켄치","탈론","트린다미어","트위치","베이가","벡스","바이","빅토르","워윅","자크","제리","직스","질리언","자이라"];
+const searchChampionName = document.getElementById("searchChampionName");
+const keywords = document.querySelector(".championKeywords");
+let keywordsFlg = false;
+function searchChampion(e){
+    let search = e.target.value;
+    let keywords = document.querySelector(".championKeywords");
+
+    if(keywords.innerHTML != "") {
+        while ( keywords.hasChildNodes() ) { keywords.removeChild( keywords.firstChild ); }
+    }
+
+    if(search === "") {
+        keywords.classList.add("hide");
+    } else {
+        keywords.classList.remove("hide");
+    }
+
+    if( search !== "") {
+        for(let i = 0; i < championNameKrList.length; i++){
+            if(championNameKrList[i].indexOf(search) !== -1){
+                const innerHtml = '<div class="championKeyword" name="' + championNameList[i] + '" onclick=insertSearchKeyword("' + i + '")>' + championNameKrList[i] + '</div>';
+                keywords.innerHTML += innerHtml;
+            }
+        }
+    }
+}
+
+function insertSearchKeyword( keyword ){
+    if(keyword.type !== "") {
+        searchChampionName.value = championNameKrList[keyword];
+    }
+    document.querySelector(".championKeywords").classList.add("hide");
+}
+
+function championSearch(){
+    let doc = document.searchChampion;
+    let searchChampionName = doc.searchChampionName.value;
+    for(let i=0; i<championNameKrList.length; i++){
+        if(searchChampionName === championNameKrList[i]){
+            doc.action = "/championList/" + championNameList[i];
+            doc.submit();
+            return "";
+        }
+    }
+    doc.action = "/championList";
+    doc.submit();
+}
+
+searchChampionName.addEventListener('input', searchChampion);
+searchChampionName.addEventListener('focus', searchChampion);
+keywords.addEventListener('mouseenter', function (){
+    keywordsFlg = true;
+});
+keywords.addEventListener('mouseleave', function (){
+    keywordsFlg = false;
+});
+searchChampionName.addEventListener('focusout', function (){
+    if(!keywordsFlg){
+        document.querySelector(".championKeywords").classList.add("hide");
+    }
+});

--- a/src/main/resources/static/js/tft/champion/championList.js
+++ b/src/main/resources/static/js/tft/champion/championList.js
@@ -16,6 +16,15 @@ function championListInit(){
         innerHtml += '</div>';
     }
     document.getElementById("championList").innerHTML += innerHtml;
+
+    let searchChampionName = document.getElementById("championName").value;
+    if(searchChampionName !== ""){
+        for( let i=0; i<championNameList.length; i++){
+            if(searchChampionName === championNameList[i]){
+                viewChampionData(championNameList[i], championNameKrList[i]);
+            }
+        }
+    }
 }
 function viewChampionData( championName,  championNameKr ){
     viewChampionImage( championName,  championNameKr );

--- a/src/main/resources/templates/fragments/bodyHeader.html
+++ b/src/main/resources/templates/fragments/bodyHeader.html
@@ -14,12 +14,17 @@
                             <button class="btn btn-outline-success" type="submit">Search</button>
                         </form>
                         <form class="searchChampion d-flex bg-dark" name="searchChampion" type="GET">
-                            <input type="search" class="form-control" id="searchChampionName" placeholder="챔피언 검색" aria-label="Search">
+                            <input type="text" class="form-control" id="searchChampionName" placeholder="챔피언 검색" aria-label="Search">
                             <button class="btn btn-outline-success" onclick="championSearch()">Search</button>
                         </form>
                     </div>
                 </div>
             </nav>
+            <div class="container d-flex flex-wrap justify-content-center justify-content-lg-start">
+                <div class="header-nav container navbar navbar-expand-md navbar-dark sticky-top">
+                    <div class="form-control championKeywords hide"></div>
+                </div>
+            </div>
         </div>
     </div>
     <nav class="navbar navbar-expand-sm navbar-light bg-light">

--- a/src/main/resources/templates/fragments/footer.html
+++ b/src/main/resources/templates/fragments/footer.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 <div class="footer" th:fragment="footer">
-    <p>&copy; coop V1</p>
+    <script th:src="@{/js/tft/bodyHeader.js}"></script>
 </div>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -43,8 +43,5 @@
         </div>
     </div>
 </body>
-<script>
-    // 해당부분은 백그라운드에 데이터를 넣는 방법중 하나 이후 비슷하게 사용할 가능성 있음
-    document.getElementById("main-background").style.backgroundImage = "url('" + "/img/shop/mainbackground_Mok.jpg" +"')";
-</script>
+<head th:replace="templates/fragments/footer.html :: footer"></head>
 </html>

--- a/src/main/resources/templates/tft/championList.html
+++ b/src/main/resources/templates/tft/championList.html
@@ -4,6 +4,7 @@
 <link th:href="@{/css/fragments/layoutChampionListPage.css}" rel="stylesheet">
 <body>
 <header th:replace="templates/fragments/bodyHeader.html :: bodyHeader"></header>
+<input type="hidden" id="championName" th:value="*{championName}">
 <div id="backgroundImage">
     <div class="container">
         <div class="championContentsAtt">


### PR DESCRIPTION
챔피언 검색 기능 추가
-> 챔피언 검색시 챔피언 리스트 화면으로 전환 입력한 챔피언 이름에 맞는게 있으면 해당 챔피언의 데이터를 초기화면으로 리스트 페이지에 표시
-> 챔피언 검색시 한글 한정으로 챔피언 이름을 확인하여서 일부 같은 경우 완성된 챔피언명이 표시되게 추가함
-> 해당 부분은 마우스 커서를 올려놓으면 색이 변하고 챔피언이름을 클릭할시 해당 이름은 챔피언 검색창에 입력되게 추가