### PR TITLE
[화면 추가] 회원 정보 수정 페이지 추가

### DIFF
--- a/src/main/java/com/projectteam/coop/web/member/MemberController.java
+++ b/src/main/java/com/projectteam/coop/web/member/MemberController.java
@@ -1,7 +1,10 @@
 package com.projectteam.coop.web.member;
 
 import com.projectteam.coop.domain.Member;
+import com.projectteam.coop.domain.Product;
 import com.projectteam.coop.service.member.MemberService;
+import com.projectteam.coop.web.argumentresolver.Login;
+import com.projectteam.coop.web.session.MemberSessionDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -11,6 +14,9 @@ import org.springframework.validation.FieldError;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
+
+import javax.servlet.http.HttpServletRequest;
+import java.net.http.HttpRequest;
 
 @Controller
 @RequiredArgsConstructor
@@ -45,6 +51,59 @@ public class MemberController {
         Member member = Member.createMember(memberForm.getEmail(), memberForm.getName(), memberForm.getPassword(), Boolean.TRUE);
         memberService.addMember(member);
 
+        return "redirect:/";
+    }
+
+    @GetMapping("/members/update")
+    public String editProfile(@Login MemberSessionDto loginMember, Model model) {
+
+        //세션에 회원 데이터 없는 경우
+        if (loginMember == null) {
+            return "redirect:/login";
+        }
+
+        Member member = memberService.findMember(loginMember.getId());
+        if (member != null) {
+            MemberForm memberForm = new MemberForm();
+            memberForm.setId(member.getId());
+            memberForm.setName(member.getName());
+            memberForm.setEmail(member.getEmail());
+            memberForm.setEmailReceptionType(member.getEmailReceptionType());
+
+
+            model.addAttribute("memberForm", memberForm);
+            return "/templates/members/updateMemberForm";
+        }
+        //회원 정보 없음
+        return "redirect:/";
+    }
+
+    @PostMapping("/members/update")
+    public String editPassword(@Login MemberSessionDto loginMember, HttpServletRequest httpRequest, Model model){
+        String currentPassword = httpRequest.getParameter("currentPassword");
+        String changePassword = httpRequest.getParameter("password");
+
+        //이메일과 패스워드가 일치하는 회원 검색
+        Member findMember = memberService.findMember(loginMember.getEmail(), currentPassword);
+        Member member = memberService.findMember(loginMember.getId());
+        MemberForm memberForm = new MemberForm();
+        memberForm.setId(member.getId());
+        memberForm.setName(member.getName());
+        memberForm.setEmail(member.getEmail());
+        memberForm.setEmailReceptionType(member.getEmailReceptionType());
+
+        if(findMember == null) {
+            if (loginMember != null) {
+                model.addAttribute("memberForm", memberForm);
+                model.addAttribute("errorMessage","입력한 현재 비밀번호가 일치하지 않습니다.");
+                return "/templates/members/updateMemberForm";
+            }
+            //회원 정보 없음
+            return "redirect:/";
+        }
+
+        memberForm.setPassword(changePassword);
+        memberService.updateMember(memberForm);
         return "redirect:/";
     }
 }

--- a/src/main/resources/static/js/updateMemberForm.js
+++ b/src/main/resources/static/js/updateMemberForm.js
@@ -1,0 +1,23 @@
+function changePassword(){
+    let doc = document.changePassword;
+    if(doc.password.value !== doc.verifyPassword.value){
+        doc.password.classList.add("border");
+        doc.password.classList.add("border-danger");
+        document.getElementById("errorPassword").classList.remove("hide");
+        doc.verifyPassword.classList.add("border");
+        doc.verifyPassword.classList.add("border-danger");
+        document.getElementById("errorVerifyPassword").classList.remove("hide");
+    }else if(doc.currentPassword.value !== "" && doc.password.value !== "" && doc.verifyPassword.value !== ""){
+        if(doc.currentPassword.value !== doc.password.value) {
+            doc.submit();
+        }else{
+            alert("현재 비밀번호와 변경할 비밀번호가 일치합니다.");
+        }
+    }else{
+        alert("입력한 비밀번호에 문제가 없는지 확인해 주세요");
+    }
+}
+
+document.getElementById("verifyButton").addEventListener('click',function (){
+    changePassword();
+});

--- a/src/main/resources/templates/fragments/bodyHeader.html
+++ b/src/main/resources/templates/fragments/bodyHeader.html
@@ -50,7 +50,7 @@
                     <div th:if="${session.loginMember ne null}">
                         <p th:text="|${session.loginMember.name}님 보유포인트: ${session.loginMember.point}|"></p>
                         <button type="button" class="btn btn-outline-dark me-2" onclick="location.href='/orders'">구매목록</button>
-                        <button type="button" class="btn btn-outline-dark me-2" onclick="location.href='#'">회원수정</button>
+                        <button type="button" class="btn btn-outline-dark me-2" onclick="location.href='/members/update'">회원수정</button>
                         <button type="button" class="btn btn-outline-dark me-2" onclick="logout()">로그아웃</button>
                     </div>
                 </div>

--- a/src/main/resources/templates/members/updateMemberForm.html
+++ b/src/main/resources/templates/members/updateMemberForm.html
@@ -1,0 +1,52 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head th:replace="templates/fragments/header.html :: header"></head>
+<body>
+<header th:replace="templates/fragments/bodyHeader.html :: bodyHeader"></header>
+<div class="container mt-5">
+    <form th:action="@{/members/update}" name="changePassword" id="changePassword" method="post" th:object="${memberForm}">
+        <div class="form-group mb-3">
+            <label th:for="email">아이디</label>
+            <input type="text" th:field="*{email}" th:value="*{email}" th:errorclass="'border border-danger'" class="form-control" disabled>
+        </div>
+        <div class="form-group mb-3 row">
+            <div class="col-sm-2">
+                <label th:for="password">비밀번호</label>
+                <input type="button" value="비밀번호 변경" class="form-control" data-bs-toggle="collapse" data-bs-target="#changePasswordArea" aria-controls="changePasswordArea" aria-expanded="false" aria-label="Toggle navigation">
+            </div>
+            <div class="col-sm-4">
+                <div th:if="${errorMessage != ''}" th:text="${errorMessage}" class="text-danger"></div>
+            </div>
+        </div>
+        <div class="collapse mb-3" name="changePasswordArea" id="changePasswordArea">
+            <label>현재 비밀번호</label>
+            <div class="mb-3">
+                <input type="password" name="currentPassword" id="currentPassword" class="form-control">
+            </div>
+            <div class="mb-3">
+                <label>비밀번호</label>
+                <input type="password" name="password" id="password" class="form-control">
+                <div class="text-danger hide" name="errorPassword" id="errorPassword">
+                    비밀번호 확인 오류
+                </div>
+            </div>
+            <div class="mb-3">
+                <label>비밀번호 확인</label>
+                <input type="password" name="verifyPassword" id="verifyPassword" class="form-control">
+                <div class="text-danger hide" name="errorVerifyPassword" id="errorVerifyPassword">
+                    비밀번호 확인 오류
+                </div>
+            </div>
+            <input type="button" class="btn btn-outline-primary" name="verifyButton" id="verifyButton" value="변경">
+        </div>
+
+        <div class="form-group mb-3">
+            <label th:for="name">닉네임</label>
+            <input ype="text" th:field="*{name}" th:value="*{name}" th:errorclass="'border border-danger'" class="form-control" disabled>
+        </div>
+    </form>
+</div>
+<footer th:replace="templates/fragments/footer.html :: footer"></footer>
+</body>
+<script th:src="@{/js/updateMemberForm.js}"></script>
+</html>


### PR DESCRIPTION
회원 정보 수정 페이지 추가
기능 -> 비밀번호 변경 기능 추가

변경버튼을 눌렀을시
-> 현재 비밀번호, 비밀번호, 비밀번호 확인에 입력이 없을시 화면 메세지 표시
submit발생하지 않음
-> 비밀번호, 비밀번호 확인 일치하지 않을시 화면 메세지 표시
submit발생하지 않음
-> 위의 조건이 충족했을시
submit 발생함
서버 컨트롤에서 입력한 현재 비밀번호를 이용해서 findMember를 구동 멤버가 없는경우 -> 회원수정 화면으로 재이동
세션에 회원 데이터 없는 경우
 -> 아무런 변화가 없이 홈 화면으로 이동
위의 경우 이외의 경우
 -> 수정된 데이터를 업데이트 한뒤 홈 화면으로 이동