### PR TITLE
[비밀번호 찾기 기능추가]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,5 +195,22 @@
             <version>1.3.2</version>
         </dependency>
 
+        <!-- SMTP 메일 관련 -->
+        <dependency>
+            <groupId>javax.mail</groupId>
+            <artifactId>mail</artifactId>
+            <version>1.4.7</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context-support</artifactId>
+            <version>${org.springframework-version}</version>
+        </dependency>
+        <!-- 랜덤 문자열 생성관련 -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.4</version>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/com/projectteam/coop/repository/member/MemberRepository.java
+++ b/src/main/java/com/projectteam/coop/repository/member/MemberRepository.java
@@ -60,6 +60,17 @@ public class MemberRepository {
         return findMember;
     }
 
+    //이메일 조회( 이메일 단독으로 조회 -> [임시 비밀번호 등록용] )
+    public Member findMemberForPassword(String email) {
+        Member member = em.createQuery("SELECT m FROM Member m WHERE m.email = :email", Member.class)
+                .setParameter("email", email)
+                .getResultList()
+                .stream()
+                .findAny()
+                .orElse(null);
+        return member;
+    }
+
     //등록
     public Long addPoint(Member member) {
         member.addPoint();

--- a/src/main/java/com/projectteam/coop/service/member/MemberService.java
+++ b/src/main/java/com/projectteam/coop/service/member/MemberService.java
@@ -36,4 +36,10 @@ public class MemberService {
     public Member findMember(String email, String password) {
         return memberRepository.findMember(email, password);
     }
+
+    //이메일 조회( 이메일 단독으로 조회 -> [임시 비밀번호 등록용] )
+    @Transactional(transactionManager = "h2TxManager", readOnly = true)
+    public Member findMemberForPassword(String Email) {
+        return memberRepository.findMemberForPassword(Email);
+    }
 }

--- a/src/main/java/com/projectteam/coop/web/mail/EmailController.java
+++ b/src/main/java/com/projectteam/coop/web/mail/EmailController.java
@@ -1,0 +1,82 @@
+package com.projectteam.coop.web.mail;
+
+import com.projectteam.coop.domain.Member;
+import com.projectteam.coop.service.member.MemberService;
+import com.projectteam.coop.web.member.MemberForm;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+
+import javax.mail.internet.MimeMessage;
+
+@Controller
+@RequiredArgsConstructor
+public class EmailController {
+
+    private final JavaMailSender mailSender;
+    private final MemberService memberService;
+
+    @GetMapping(value = "/mail")
+    public String getMailAdd(Model model){
+        model.addAttribute("emailForm", new EmailForm());
+        return "/templates/mail/forgotPassword";
+    }
+
+    // mailSending 코드
+    @PostMapping(value = "/mail")
+    public String mailSending(@Validated @ModelAttribute("emailForm") EmailForm emailForm,
+                              BindingResult bindingResult) {
+
+        if (bindingResult.hasErrors()) {
+            return "/templates/mail/forgotPassword";
+        }
+
+        //이메일과 패스워드가 일치하는 회원 검색
+        Member findMember = memberService.findMemberForPassword(emailForm.getEmail());
+
+        if(findMember == null){
+            bindingResult.reject("memberNotFound");
+            return "/templates/mail/forgotPassword";
+        }
+        String randomPassword = RandomStringUtils.randomAlphanumeric(12);
+        MemberForm memberForm = new MemberForm();
+        memberForm.setId(findMember.getId());
+        memberForm.setName(findMember.getName());
+        memberForm.setPassword(randomPassword);
+        memberForm.setEmail(findMember.getEmail());
+        memberForm.setEmailReceptionType(findMember.getEmailReceptionType());
+        memberService.updateMember(memberForm);
+
+        String setfrom = "TFTInfo";
+        String tomail = emailForm.getEmail(); // 받는 사람 이메일
+        String title = "TFTInfo 임시 비밀번호에 대해서"; // 제목
+        String content = "요청하신 임시비밀번호는 아래와 같습니다.\n\n" +
+                randomPassword +
+                "\n\nhttp://localhost:8080/login 으로 접속해 로그인 한뒤 비밀번호를 반드시 변경해주시길 바랍니다."; // 로컬 호스트 기준
+
+        try {
+            MimeMessage message = mailSender.createMimeMessage();
+            MimeMessageHelper messageHelper = new MimeMessageHelper(message,
+                    true, "UTF-8");
+
+            messageHelper.setFrom(setfrom); // 보내는사람 생략하면 정상작동을 안함
+            messageHelper.setTo(tomail); // 받는사람 이메일
+            messageHelper.setSubject(title); // 메일제목은 생략이 가능하다
+            messageHelper.setText(content); // 메일 내용
+
+            mailSender.send(message);
+        } catch (Exception e) {
+            System.out.println(e);
+        }
+
+        return "/templates/mail/mailResultPage";
+    }
+}

--- a/src/main/java/com/projectteam/coop/web/mail/EmailController.java
+++ b/src/main/java/com/projectteam/coop/web/mail/EmailController.java
@@ -5,6 +5,7 @@ import com.projectteam.coop.service.member.MemberService;
 import com.projectteam.coop.web.member.MemberForm;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Controller;
@@ -16,6 +17,8 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 
 import javax.mail.internet.MimeMessage;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 
 @Controller
 @RequiredArgsConstructor
@@ -23,6 +26,8 @@ public class EmailController {
 
     private final JavaMailSender mailSender;
     private final MemberService memberService;
+    @Value("${tomcat.server.port}")
+    private String serverPort;
 
     @GetMapping(value = "/mail")
     public String getMailAdd(Model model){
@@ -55,12 +60,21 @@ public class EmailController {
         memberForm.setEmailReceptionType(findMember.getEmailReceptionType());
         memberService.updateMember(memberForm);
 
+        InetAddress local;
+        String ip = "";
+        try {
+            local = InetAddress.getLocalHost();
+            ip = local.getHostAddress();
+        } catch (UnknownHostException e1) {
+            e1.printStackTrace();
+        }
+
         String setfrom = "TFTInfo";
         String tomail = emailForm.getEmail(); // 받는 사람 이메일
         String title = "TFTInfo 임시 비밀번호에 대해서"; // 제목
         String content = "요청하신 임시비밀번호는 아래와 같습니다.\n\n" +
                 randomPassword +
-                "\n\nhttp://localhost:8080/login 으로 접속해 로그인 한뒤 비밀번호를 반드시 변경해주시길 바랍니다."; // 로컬 호스트 기준
+                "\n\nhttp://" + ip + ":" + serverPort + "/login 으로 접속해 로그인 한뒤 비밀번호를 반드시 변경해주시길 바랍니다."; // 로컬 호스트 기준
 
         try {
             MimeMessage message = mailSender.createMimeMessage();

--- a/src/main/java/com/projectteam/coop/web/mail/EmailForm.java
+++ b/src/main/java/com/projectteam/coop/web/mail/EmailForm.java
@@ -1,0 +1,16 @@
+package com.projectteam.coop.web.mail;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotEmpty;
+
+@Getter
+@Setter
+public class EmailForm {
+
+    @Email
+    @NotEmpty
+    private String email;
+}

--- a/src/main/resources/templates/login/loginForm.html
+++ b/src/main/resources/templates/login/loginForm.html
@@ -31,7 +31,10 @@
             </label>
         </div>
         <button class="w-100 mb-1 btn btn-lg btn-primary" type="submit">로그인</button>
-        <button class="w-100 btn btn-lg btn-dark" type="button" onclick="location.href='/members/new'">회원가입</button>
+        <button class="w-100 mb-1 btn btn-lg btn-dark" type="button" onclick="location.href='/members/new'">회원가입</button>
+        <div class="row justify-content-sm-end w-100">
+            <a class="btn col-sm-6" type="button" href="/mail">비밀번호 찾기</a>
+        </div>
     </form>
 </div>
 <br/>

--- a/src/main/resources/templates/mail/forgotPassword.html
+++ b/src/main/resources/templates/mail/forgotPassword.html
@@ -1,0 +1,28 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head th:replace="templates/fragments/header.html :: header"></head>
+<body class="text-center">
+<header th:replace="templates/fragments/bodyHeader.html :: bodyHeader"></header>
+
+<div class="form-signin">
+    <form th:action th:object="${emailForm}" method="post">
+        <img class="mb-4" src="/img/login/logo.png" alt="" width="72" height="57">
+        <div class="text-start mb-1">임시 비밀번호를 받을 이메일 주소를 입력해 주십시오</div>
+        <div class="form-floating">
+            <input class="mb-2 form-control" th:errorclass="'border border-danger'" th:field="*{email}" placeholder="name@example.com">
+            <label th:for="email">Email address</label>
+            <div class="text-danger" th:errors="*{email}">
+                이메일 오류
+            </div>
+            <div th:if="${#fields.hasGlobalErrors()}">
+                <p class="text-danger" th:each="err : ${#fields.globalErrors()}" th:text="${err}">글로벌 오류 메시지</p>
+            </div>
+        </div>
+        <div class="row justify-content-sm-end w-100">
+            <button class="btn col-sm-6" type="submit">비밀번호 찾기</button>
+        </div>
+    </form>
+</div>
+<footer th:replace="templates/fragments/footer.html :: footer"></footer>
+</body>
+</html>

--- a/src/main/resources/templates/mail/mailResultPage.html
+++ b/src/main/resources/templates/mail/mailResultPage.html
@@ -1,0 +1,15 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head th:replace="templates/fragments/header.html :: header"></head>
+<body class="text-center">
+<header th:replace="templates/fragments/bodyHeader.html :: bodyHeader"></header>
+
+<div class="form-signin">
+    <form>
+        <img class="mb-4" src="/img/login/logo.png" alt="" width="72" height="57">
+        <div class="text-start mb-1">이메일 전송이 완료되었습니다. 입력하신 이메일을 확인해 주십시오</div>
+    </form>
+</div>
+<footer th:replace="templates/fragments/footer.html :: footer"></footer>
+</body>
+</html>

--- a/src/main/webapp/WEB-INF/spring/appServlet/servlet-context.xml
+++ b/src/main/webapp/WEB-INF/spring/appServlet/servlet-context.xml
@@ -183,8 +183,8 @@
     <bean id="mailSender" class="org.springframework.mail.javamail.JavaMailSenderImpl">
         <property name="host" value="smtp.gmail.com"/>
         <property name="port" value="587" />
-        <property name="username" value="tfttoyproject@gmail.com"/> <!-- 자신의 이메일 아이디 -->
-        <property name="password" value="1243qwre!"/> <!-- 자신의 비밀번호 -->
+        <property name="username" value="${mail.sender.username}"/> <!-- 자신의 이메일 아이디 -->
+        <property name="password" value="${mail.sender.password}"/> <!-- 자신의 비밀번호 -->
         <!-- 보안연결 TLS과 관련된 설정 -->
         <property name="javaMailProperties">
             <props>

--- a/src/main/webapp/WEB-INF/spring/appServlet/servlet-context.xml
+++ b/src/main/webapp/WEB-INF/spring/appServlet/servlet-context.xml
@@ -30,6 +30,7 @@
             <mvc:exclude-mapping path="/error" />
             <mvc:exclude-mapping path="/adminLogin" />
             <mvc:exclude-mapping path="/login" />
+            <mvc:exclude-mapping path="/mail/**" />
             <mvc:exclude-mapping path="/logout" />
             <mvc:exclude-mapping path="/members/new" />
             <mvc:exclude-mapping path="/tft/**" />
@@ -177,5 +178,23 @@
         </property>
         <property name="defaultEncoding" value="utf-8" />
         <property name="cacheSeconds" value="60" />
+    </bean>
+    <!-- mail 관련 bean추가 -->
+    <bean id="mailSender" class="org.springframework.mail.javamail.JavaMailSenderImpl">
+        <property name="host" value="smtp.gmail.com"/>
+        <property name="port" value="587" />
+        <property name="username" value="tfttoyproject@gmail.com"/> <!-- 자신의 이메일 아이디 -->
+        <property name="password" value="1243qwre!"/> <!-- 자신의 비밀번호 -->
+        <!-- 보안연결 TLS과 관련된 설정 -->
+        <property name="javaMailProperties">
+            <props>
+                <prop key="mail.smtp.auth">true</prop>
+                <prop key="mail.smtp.starttls.enable">true</prop>
+                <prop key="mail.transport.protocol">smtp</prop>
+                <prop key="mail.debug">true</prop>
+                <prop key="mail.smtp.ssl.trust">smtp.gmail.com</prop>
+                <prop key="mail.smtp.ssl.protocols">TLSv1.2</prop>
+            </props>
+        </property>
     </bean>
 </beans>


### PR DESCRIPTION
로그인 화면에 비밀번호 찾기 버튼 추가
Member 관련 접근에 Email단독 처리 추가 -> 입력한 이메일 관련 데이터 여부, 임시 비밀번호 입력관련에 사용

forgotPassword.html
이메일 입력 부분과 비밀번호 찾기 버튼 존재
기존 에러 메세지 관련 에러 기능 있음
에러가 발생하지 않았을시 임시 비밀번호를 생성뒤 저장한뒤 해당 이메일로 메세지 전송
전송이 완료되면 mailResultPage.html 로 이동