### PR TITLE
[게시판 기능] 게시물 비밀번호 페이지 추가 및 닉네임 회원, 비회원 구분 표시 처리

### DIFF
--- a/src/main/java/com/projectteam/coop/domain/Comment.java
+++ b/src/main/java/com/projectteam/coop/domain/Comment.java
@@ -83,6 +83,7 @@ public class Comment extends BaseEntity {
         comment.password = password;
         comment.status = Boolean.TRUE;
         comment.content = content;
+        comment.nickname = createMember.getName();
         comment.createMember = createMember;
         comment.order = 0L;
         comment.depth = 0L;
@@ -111,6 +112,7 @@ public class Comment extends BaseEntity {
         comment.password = password;
         comment.status = Boolean.TRUE;
         comment.content = content;
+        comment.nickname = createMember.getName();
         comment.createMember = createMember;
         comment.parent = parent;
         comment.group = parent.getGroup();

--- a/src/main/java/com/projectteam/coop/domain/Post.java
+++ b/src/main/java/com/projectteam/coop/domain/Post.java
@@ -88,6 +88,7 @@ public class Post extends BaseEntity {
         post.content = content;
         post.viewCount = 0;
         post.recommendCount = 0L;
+        post.nickname = createMember.getName();
         post.createMember = createMember;
         post.parent = parent;
         post.group = parent.getGroup();
@@ -106,7 +107,6 @@ public class Post extends BaseEntity {
         post.viewCount = 0;
         post.recommendCount = 0L;
         post.nickname = nickname;
-//        post.parent = post;
         post.order = 0L;
         post.depth = 0L;
 
@@ -121,26 +121,24 @@ public class Post extends BaseEntity {
         post.content = content;
         post.viewCount = 0;
         post.recommendCount = 0L;
+        post.nickname = createMember.getName();
         post.createMember = createMember;
-//        post.parent = post;
         post.order = 0L;
         post.depth = 0L;
 
         return post;
     }
 
-    public void changePost(Board board, PostStatus postStatus, String password, String title, String content, Integer viewCount, Long recommendCount) {
+    public void changePost(Board board, String nickname, String password, String title, String content) {
         this.board = board;
-        this.postStatus = postStatus;
+        this.nickname = nickname;
         this.password = password;
         this.title = title;
         this.content = content;
-        this.viewCount = viewCount;
-        this.recommendCount = recommendCount;
     }
 
     //추천
-    public void recommed(Long recommendCount) {
+    public void recommend(Long recommendCount) {
         this.recommendCount = recommendCount;
     }
 

--- a/src/main/java/com/projectteam/coop/repository/post/PostRepository.java
+++ b/src/main/java/com/projectteam/coop/repository/post/PostRepository.java
@@ -49,7 +49,7 @@ public class PostRepository {
 
     //목록 조회
     public List<Post> findPosts(int offset, int size) {
-        List<Post> findPosts = em.createQuery("select p from Post p left join fetch p.parent order by p.group desc, p.order asc", Post.class)
+        List<Post> findPosts = em.createQuery("select p from Post p left join fetch p.createMember order by p.group desc, p.order asc", Post.class)
                 .setFirstResult(offset)
                 .setMaxResults(size)
                 .getResultList();

--- a/src/main/java/com/projectteam/coop/service/post/PostService.java
+++ b/src/main/java/com/projectteam/coop/service/post/PostService.java
@@ -43,15 +43,14 @@ public class PostService {
         return postRepository.addPost(post);
     }
 
-    public Long addPost(PostCreateForm postForm, Optional<MemberSessionDto> memberSession) {
+    public Long addPost(PostCreateForm postForm, Optional<MemberSessionDto> loginMember) {
 
         Post post;
-        if(memberSession.isEmpty()) {
+        if(loginMember.isEmpty()) {
             post = Post.createPost(postForm.getTitle(), postForm.getPassword(), postForm.getContent(), postForm.getNickname());
         }else {
-            MemberSessionDto session = memberSession.get();
+            MemberSessionDto session = loginMember.get();
             Member member = memberRepository.findMember(session.getId());
-
             post = Post.createPost(postForm.getTitle(), postForm.getPassword(), postForm.getContent(), member);
         }
 
@@ -71,13 +70,12 @@ public class PostService {
     public Post findPost(Long id) {
         Post post = postRepository.findPost(id);
         post.addViewCount();
-
         return post;
     }
 
     public void updatePost(PostUpdateForm postForm) {
         Post post = postRepository.findPost(postForm.getPostId());
-        post.changePost(post.getBoard(), post.getPostStatus(), postForm.getPassword(), postForm.getTitle(), postForm.getContent(), post.getViewCount(), post.getRecommendCount());
+        post.changePost(post.getBoard(), postForm.getNickname(), postForm.getPassword(), postForm.getTitle(), postForm.getContent());
     }
 
     //게시물 추천 등록
@@ -86,7 +84,7 @@ public class PostService {
         Post post = postRepository.findPost(postId);
 
         recommendRepository.addRecommend(Recommend.createRecommed(post, member));
-        post.recommed(recommendRepository.getPostRecommendCount(postId));
+        post.recommend(recommendRepository.getPostRecommendCount(postId));
     }
 
     public int totalSize() {

--- a/src/main/java/com/projectteam/coop/web/post/PostCreateForm.java
+++ b/src/main/java/com/projectteam/coop/web/post/PostCreateForm.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.validator.constraints.Length;
 
-import javax.validation.constraints.*;
+import javax.validation.constraints.NotEmpty;
 
 @Getter
 @Setter
@@ -18,7 +18,6 @@ public class PostCreateForm {
     @Length(min = 4, max = 4)
     private String password;
 
-    @NotEmpty
     private String nickname;
 
     private String content;

--- a/src/main/java/com/projectteam/coop/web/post/PostUpdateForm.java
+++ b/src/main/java/com/projectteam/coop/web/post/PostUpdateForm.java
@@ -1,10 +1,10 @@
 package com.projectteam.coop.web.post;
 
+import com.projectteam.coop.domain.Member;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.validator.constraints.Length;
 
-import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
@@ -21,10 +21,11 @@ public class PostUpdateForm {
     @Length(min = 4, max = 4)
     private String password;
 
-    @NotEmpty
     private String nickname;
 
     private String content;
+
+    private Member createMember;
 
     private Long upperPostId;
 }

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -34,7 +34,7 @@
                                 <th class="text-gray-900" scope="row">
                                     <a th:href="@{/posts/{postId}(postId=${post.postId})}" th:text="${post.title}"></a>
                                 </th>
-                                <td class="fw-bolder text-gray-500" th:text="${post.createMember eq null} ? ${post.nickname} : ${post.createMember.name}"></td>
+                                <td class="fw-bolder text-gray-500" th:text="${post.nickname}"></td>
                                 <td class="fw-bolder text-gray-500" th:text="${post.recommendCount}"></td>
                             </tr>
                         </tbody>

--- a/src/main/resources/templates/posts/createPostForm.html
+++ b/src/main/resources/templates/posts/createPostForm.html
@@ -13,7 +13,7 @@
           게시물 제목 오류
         </div>
       </div>
-      <div class="form-group mb-3">
+      <div class="form-group mb-3" th:if="${session.loginMember eq null}">
         <label th:for="nickname">닉네임</label>
         <input type="text" th:field="*{nickname}" th:errorclass="'border border-danger'" class="form-control" placeholder="닉네임을 입력하세요">
         <div class="text-danger" th:errors="*{nickname}">

--- a/src/main/resources/templates/posts/passwordForm.html
+++ b/src/main/resources/templates/posts/passwordForm.html
@@ -1,0 +1,21 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head th:replace="templates/fragments/header.html :: header"></head>
+<body class="text-center">
+<header th:replace="templates/fragments/bodyHeader.html :: bodyHeader"></header>
+
+<div class="form-signin">
+  <form th:action method="get">
+    <img class="mb-4" src="/img/login/logo.png" alt="" width="72" height="57">
+    <div class="form-floating mb-2">
+      <label th:for="postPassword" class="pb-2">Password</label>
+      <input type="password" class="form-control" th:id="postPassword" th:name="postPassword" placeholder="비밀번호를 입력하세요">
+    </div>
+    <button class="w-100 mb-1 btn btn-lg btn-primary" type="submit">확인</button>
+    <button class="w-100 btn btn-lg btn-dark" type="button" onclick="javascript:history.back();">취소</button>
+  </form>
+</div>
+<br/>
+<footer th:replace="templates/fragments/footer.html :: footer"></footer>
+</body>
+</html>

--- a/src/main/resources/templates/posts/postInfo.html
+++ b/src/main/resources/templates/posts/postInfo.html
@@ -10,6 +10,11 @@
         <p class="form-control" th:field="*{title}" th:text="*{title}"></p>
       </div>
       <div class="form-group">
+        <label th:for="title">작성자</label>
+        <p class="form-control" th:text="*{nickname}"></p>
+      </div>
+
+      <div class="form-group">
         <label th:for="content">내용</label>
         <textarea th:field="*{content}" th:text="*{content}" class="form-control" style="resize: none; height: 200px;" readonly></textarea>
       </div>

--- a/src/main/resources/templates/posts/postList.html
+++ b/src/main/resources/templates/posts/postList.html
@@ -13,7 +13,7 @@
                     <th scope="col">제목</th>
                     <th scope="col">조회수</th>
                     <th scope="col">추천수</th>
-<!--                    <th scope="col">작성자</th>-->
+                    <th scope="col">작성자</th>
                 </tr>
             </thead>
             <tbody>
@@ -27,11 +27,10 @@
                             [답글]
                         </span>
                         <a th:text="${post.title}" th:href="'javascript:infoGet(\'posts\',' + ${post.postId} + ')'" href="#"></a>
-<!--                            <a th:if="${child.parent.postId == post.postId}" th:each="child : ${post?.child}"  th:text="|&nbsp;&nbsp;&nbsp;답글 : ${child.title}|" th:href="'javascript:infoGet(\'posts\',' + ${child.postId} + ')'" href="#"></a>-->
                     </td>
                     <td th:text="${post.viewCount}"></td>
                     <td th:text="${post.recommendCount}"></td>
-<!--                    <td th:text="${post.createMember.name}"></td>-->
+                    <td th:text="${post.nickname}"></td>
                 <td></td>
                 </tr>
             </tbody>

--- a/src/main/resources/templates/posts/updatePostForm.html
+++ b/src/main/resources/templates/posts/updatePostForm.html
@@ -13,8 +13,8 @@
           게시물 제목 오류
         </div>
       </div>
-      <div class="form-group mb-3">
-        <label th:for="title">닉네임</label>
+      <div class="form-group mb-3" th:if="*{createMember eq null}">
+        <label th:for="nickname">닉네임</label>
         <input type="text" th:field="*{nickname}" th:errorclass="'border border-danger'" class="form-control" placeholder="닉네임을 입력하세요">
         <div class="text-danger" th:errors="*{nickname}">
           닉네임 오류


### PR DESCRIPTION
게시물 수정 시 비밀번호 입력해서 일치하면 수정되고 회원 본인 글은 본인만 수정 다른 회원글 수정 불가능, 비회원글은 비회원이든 회원이든 수정가능하게 변경했고 작성자 표시도 회원 글은 회원 닉네임으로 표시되고 비회원은 닉네임으로 표시되도록 처리했으니 확인해줘